### PR TITLE
Added relationships to FoodCollect, Created new session api

### DIFF
--- a/backend/app/main/crud.py
+++ b/backend/app/main/crud.py
@@ -45,6 +45,7 @@ def create_food(session: Session, food: schemas.FoodCreate):
         description=food.description,
         category=food.category,
         serving_size=food.serving_size,
+        food_collect_id=food.food_collect_id,
     )
     session.add(db_food)
     session.commit()

--- a/backend/app/main/main.py
+++ b/backend/app/main/main.py
@@ -238,6 +238,23 @@ def update_food_collect(
     return db_update_food_collect
 
 
+@router.post("/new_session", response_model=int)
+def begin_new_session(
+    food_collect: schemas.FoodCollectCreate, session: Session = Depends(get_db)
+):
+    """
+    Adds new food_collect, then returns its id for future operations
+
+    :return: JSON response with id of the created entry 
+    """
+    db_vendor_id = crud.get_vendor_by_id(session, id=food_collect.vendor_id)
+    if db_vendor_id is None:
+        raise HTTPException(status_code=404, detail="Vendor not registered")
+
+    db_food_collect = crud.create_food_collect(session, food_collect)
+    return db_food_collect.id
+
+
 @router.post("/add_user", response_model=schemas.User)
 def create_user(user: schemas.UserCreate, session: Session = Depends(get_db)):
     """

--- a/backend/app/main/models.py
+++ b/backend/app/main/models.py
@@ -49,6 +49,12 @@ class Food(Base):
     category = Column(Enum(FoodEnum), nullable=False)
     serving_size = Column(String)
 
+    # Foreign Keys
+    food_collect_id = Column(Integer, ForeignKey("food_collects.id"))
+
+    # Relationships
+    food_collect = relationship("FoodCollect")
+
 
 class Tray(Base):
     __tablename__ = "trays"
@@ -56,15 +62,15 @@ class Tray(Base):
     id = Column(Integer, primary_key=True, index=True)
     type = Column(String)
     date_acquired = Column(DateTime, default=datetime.now())
-    vendor_id = Column(Integer, ForeignKey("vendors.id"))
     description = Column(String)
 
-    vendor = relationship("Vendor", back_populates="trays")
-    # Relationships
-    food_collect = relationship("FoodCollect")
-
-    # Foreign keys
+    # Foreign Keys
+    vendor_id = Column(Integer, ForeignKey("vendors.id"))
     food_collect_id = Column(Integer, ForeignKey("food_collects.id"))
+
+    # Relationships
+    vendor = relationship("Vendor", back_populates="trays")
+    food_collect = relationship("FoodCollect")
 
 
 class FoodCollect(Base):

--- a/backend/app/main/schemas.py
+++ b/backend/app/main/schemas.py
@@ -10,6 +10,7 @@ class TrayBase(BaseModel):
     type: str
     date_acquired: datetime = datetime.now
     description: str = ""
+    food_collect_id: int
 
 
 class TrayCreate(TrayBase):
@@ -50,6 +51,7 @@ class FoodBase(BaseModel):
     description: str = ""
     category: FoodEnum
     serving_size: str = ""
+    food_collect_id: int
 
 
 class FoodCreate(FoodBase):

--- a/backend/tests/api/test_main.py
+++ b/backend/tests/api/test_main.py
@@ -27,14 +27,29 @@ class MainTest(BasicApiTestCase):
         # TODO: remove entry from db
 
     def test_food(self):
+        # Add vendor and foodCollect first
+        vendor = {
+            "name": "ratatas",
+            "address": "orchard road",
+            "city": "sinnoh",
+        }
+        response = self.app.post("/add_vendor", json=vendor)
+
         payload = {
-            "name": "Pineapple pizza",
-            "weight": 500,
+            "pickup_time": "2020-11-08 11:11:51.291273",
+            "vendor_id": 1,
+        }
+        response = self.app.post("/add_food_collect", json=payload)
+
+        payload = {
+            "name": "Pepperoni pizza",
+            "weight": 502,
             "date_produced": "2020-03-11",
-            "expiry_date": "2021-04-12",
+            "expiry_date": "2023-04-12",
             "description": "The best pizza in town",
             "category": "Grains, Beans and Nuts",
             "serving_size": "4",
+            "food_collect_id": 1,
         }
         response = self.app.post("/add_food", json=payload)
         assert response.status_code == 200
@@ -51,6 +66,7 @@ class MainTest(BasicApiTestCase):
             "decription": "victory hw",
             "category": "Vegetables",
             "serving_size": "1",
+            "food_collect_id": 1,
         }
         response = self.app.post("/add_food", json=add_food_payload)
 
@@ -64,10 +80,18 @@ class MainTest(BasicApiTestCase):
         assert response.status_code == 200
 
     def test_vendors_tray(self):
+        # Add food_collects first
+        payload = {
+            "pickup_time": "2020-11-11 11:11:51.291273",
+            "vendor_id": 1,
+        }
+        response = self.app.post("/add_food_collect", json=payload)
+
         payload = {
             "type": "metal",
             "date_acquired": "2020-05-09 22:56:51.291273",
             "description": "from the pizza",
+            "food_collect_id": 1,
         }
         response = self.app.post("/vendors/1/add_tray", json=payload)
         assert response.status_code == 200
@@ -96,6 +120,21 @@ class MainTest(BasicApiTestCase):
 
     def test_get_all_food_collect(self):
         response = self.app.get("/get_all_food_collect")
+        assert response.status_code == 200
+
+    def test_create_new_session(self):
+        vendor = {
+            "name": "Pizza Boys",
+            "address": "Pepperoni road",
+            "city": "Seoul",
+        }
+        response = self.app.post("/add_vendor", json=vendor)
+
+        payload = {
+            "pickup_time": "2020-10-10 11:11:51.291277",
+            "vendor_id": 1,
+        }
+        response = self.app.post("/new_session", json=payload)
         assert response.status_code == 200
 
     # TODO: test it after having a test db with data


### PR DESCRIPTION
# Description

- Added one to many relationships between FoodCollect and Tray
- Added one to many relationships between FoodCollect and Food
- Created endpoint /new_session, which creates new FoodCollect object and returns its id
   - If merged, frontend will use this id to call relevant apis ( e.g adding food to foodcollect) (not made yet) during its 'session'
   - This is made, since I believe frontend doesn't need to know/get FoodCollect object in backend at all when starting a new session. Rather, have a simple integer variable (which is also lighter) that can be used for any api calls regarding session in the future.
 - Added testing for the route added



Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.  
Provide instructions so we can **reproduce**.  
Please also list any relevant details for your test configuration

- [x] Manual api testing through postman
- [x] python3 -m unittest discover tests/api

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I will rebase before merging
